### PR TITLE
Update init.lua

### DIFF
--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -290,7 +290,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 						do
 							local flagForUpdate = false
 							-- Don't check them if they're server-owned
-							if root:CanSetNetworkOwnership() and root:GetNetworkOwner() ~= player then
+							if not root:CanSetNetworkOwnership() or root:GetNetworkOwner() ~= player then
 								physicsData.InitialCFrame = root.CFrame
 								physicsData.InitialVelocity = root.AssemblyLinearVelocity
 								physicsData.Acceleration = root.AssemblyLinearVelocity - (physicsData.InitialVelocity or Vector3.new())


### PR DESCRIPTION
On #6 I added a feature where I fixed a bug with network ownership. However it introduced a new bug which makes it so that if the network ownership cannot be set then the anti cheat will stay enabled. So this makes is to that if for example the rootpart is anchored or for some other reason doesn't have network ownership the anticheat will also be disabled.