### PR TITLE
Added a hat drop check.

### DIFF
--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -22,6 +22,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local PhysicsService = game:GetService("PhysicsService")
 local RunService = game:GetService("RunService")
 local StarterPlayer = game:GetService("StarterPlayer")
+local Players = game:GetService("Players")
 
 local StarterCharacterScripts = StarterPlayer:WaitForChild("StarterCharacterScripts")
 local LocalLinker = ReplicatedStorage:FindFirstChild("LocalLinker")
@@ -198,10 +199,11 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 							local connection
 							connection = child.AncestryChanged:Connect(function(_, parent)
 								-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
-								if parent == character then
+								if parent == character or Players:GetPlayerFromCharacter(parent) then
 									return
 								end
 
+								humanoid:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
 								-- Invalid hat drop or hat got destroyed
 								stillConnected[child] = nil
 								child:Destroy()
@@ -643,8 +645,6 @@ function Anticheat:Start()
 	if not PlayerManager then
 		local players = {}
 		PlayerManager = {Players = players}
-
-		local Players = game:GetService("Players")
 
 		local function setupPlayer(player)
 			players[player] = {}

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -207,9 +207,10 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									connection:Disconnect()
 									connection = nil
 									child:Destroy() -- Character is missing or respawned. Accroutrements should exist after this so we must clear it.
+									return
 								end
 
-								humanoid:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
+								child:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
 								-- Invalid hat drop or hat got destroyed
 								stillConnected[child] = nil
 								if Anticheat.ChecksEnabled.DestroyDroppedHats then

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -202,18 +202,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
 								if parent == character or Players:GetPlayerFromCharacter(parent) then
 									return
-								elseif not character or not character:IsDescendantOf(game) then
-									stillConnected[child] = nil
-									connection:Disconnect()
-									connection = nil
-									child:Destroy() -- Character is missing or respawned. Accroutrements should exist after this so we must clear it.
-									return
 								end
 
 								child:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
 								-- Invalid hat drop or hat got destroyed
 								stillConnected[child] = nil
-								if Anticheat.ChecksEnabled.DestroyDroppedHats then
+								if Anticheat.ChecksEnabled.DestroyDroppedHats or not character or not character:IsDescendantOf(game)  then
 									child:Destroy()
 								else
 									child.Parent = character

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,8 +61,8 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	PreventParentAccroutrements = true, -- If players can drop and/or delete hats(and other accessories). If you have hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to false.
-	DestroyDroppedHats = true, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
+	PreventParentAccoutrements = true, -- If players can drop and/or delete hats(and other accessories). If you have a custom hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed.
+	DestroyDroppedAccoutrements = true, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player
@@ -195,7 +195,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 					end
 
 					local stillConnected = setmetatable({}, {__mode="kv"})
-					local function ConnectHatDrop(child)
+					local function ConnectAccoutrementDrop(child)
 						if not stillConnected[child] then
 							local connection
 							connection = child.AncestryChanged:Connect(function(_, parent)
@@ -205,11 +205,11 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								end
 
 								child:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
-								-- Invalid hat drop or hat got destroyed
+								-- Invalid accoutrement drop or accoutrement got destroyed
 								stillConnected[child] = nil
 								connection:Disconnect()
 								connection = nil
-								if Anticheat.ChecksEnabled.DestroyDroppedHats or not character or not character:IsDescendantOf(game)  then
+								if Anticheat.ChecksEnabled.DestroyDroppedAccoutrements or not character or not character:IsDescendantOf(game)  then
 									child:Destroy()
 								else
 									child.Parent = character
@@ -277,15 +277,15 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and Anticheat.ChecksEnabled.PreventParentAccroutrements then
-							ConnectHatDrop(child)
+						elseif child:IsA("Accoutrement") and Anticheat.ChecksEnabled.PreventParentAccoutrements then
+							ConnectAccoutrementDrop(child)
 						end
 					end)
 
-					if Anticheat.ChecksEnabled.PreventParentAccroutrements then
+					if Anticheat.ChecksEnabled.PreventParentAccoutrements then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
-								ConnectHatDrop(child)
+								ConnectAccoutrementDrop(child)
 							end
 						end
 					end

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,7 +61,8 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	PreventParentAccoutrements = true, -- If players can drop and/or delete hats(and other accessories). If you have a custom hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed.
+	PreventAccoutrementDrop = true, -- If players can drop and hats(and other accessories). If you have a custom hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed.
+	AccroutrementDeletion = true, -- If it prevents the deletion of accroutrements. Note you will have to have PreventParentAccoutrements on.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player
@@ -208,7 +209,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								stillConnected[child] = nil
 								connection:Disconnect()
 								connection = nil
-								if character or character:IsDescendantOf(game) then
+								if (character and character:IsDescendantOf(game)) and (not child.Parent and Anticheat.ChecksEnabled.AccroutrementDeletion or child.Parent == workspace and Anticheat.ChecksEnabled.PreventAccoutrementDrop) then
 									child.Parent = character
 								end
 							end)
@@ -274,12 +275,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and Anticheat.ChecksEnabled.PreventParentAccoutrements then
+						elseif child:IsA("Accoutrement") and (Anticheat.ChecksEnabled.PreventAccoutrementDrop or Anticheat.ChecksEnabled.AccroutrementDeletion) then
 							ConnectAccoutrementDrop(child)
 						end
 					end)
 
-					if Anticheat.ChecksEnabled.PreventParentAccoutrements then
+					if Anticheat.ChecksEnabled.PreventAccoutrementDrop or Anticheat.ChecksEnabled.AccroutrementDeletion then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
 								ConnectAccoutrementDrop(child)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -62,7 +62,6 @@ Anticheat.ChecksEnabled = {
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
 	PreventParentAccoutrements = true, -- If players can drop and/or delete hats(and other accessories). If you have a custom hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed.
-	DestroyDroppedAccoutrements = false, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player
@@ -209,9 +208,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								stillConnected[child] = nil
 								connection:Disconnect()
 								connection = nil
-								if Anticheat.ChecksEnabled.DestroyDroppedAccoutrements or not character or not character:IsDescendantOf(game)  then
-									child:Destroy()
-								else
+								if character or character:IsDescendantOf(game) then
 									child.Parent = character
 								end
 							end)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,8 +61,8 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	CanDropAccroutements = false, -- If players can drop hats(and other accessories) via a hat drop script. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
-	DestroyDroppedHats = true, -- If invalidly dropped and/or deleted accroutements(hats and accessories) get deleted or parented back to the character.
+	CanDropAccroutrements = false, -- If players can drop hats(and other accessories) via a hat drop script. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
+	DestroyDroppedHats = true, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player
@@ -282,12 +282,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanDropAccroutements then
+						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanDropAccroutrements then
 							ConnectHatDrop(child)
 						end
 					end)
 
-					if not Anticheat.ChecksEnabled.CanDropAccroutements then
+					if not Anticheat.ChecksEnabled.CanDropAccroutrements then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
 								ConnectHatDrop(child)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -200,20 +200,20 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 							local connection
 							connection = child.AncestryChanged:Connect(function(_, parent)
 								-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
-								if parent == character or Players:GetPlayerFromCharacter(parent) then
+								if child.Parent == character or Players:GetPlayerFromCharacter(child.Parent) or child.Parent:FindFirstChildOfClass("Humanoid") then -- Makes stuff like admin commands which exchange hats work.
 									return
 								end
 
 								child:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
 								-- Invalid hat drop or hat got destroyed
 								stillConnected[child] = nil
+								connection:Disconnect()
+								connection = nil
 								if Anticheat.ChecksEnabled.DestroyDroppedHats or not character or not character:IsDescendantOf(game)  then
 									child:Destroy()
 								else
 									child.Parent = character
 								end
-								connection:Disconnect()
-								connection = nil
 							end)
 							stillConnected[child] = connection
 						end

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -62,7 +62,7 @@ Anticheat.ChecksEnabled = {
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
 	PreventAccoutrementDrop = true, -- If players can drop and hats(and other accessories). Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop scripts turn this to false.
-	AccroutrementDeletion = true, -- If it prevents the deletion of accoutrements.
+	AccoutrementDeletion = true, -- If it prevents the deletion of accoutrements.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player
@@ -209,7 +209,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								stillConnected[child] = nil
 								connection:Disconnect()
 								connection = nil
-								if (character and character:IsDescendantOf(game)) and (not child.Parent and Anticheat.ChecksEnabled.AccroutrementDeletion or child.Parent == workspace and Anticheat.ChecksEnabled.PreventAccoutrementDrop) then
+								if (character and character:IsDescendantOf(game)) and (not child.Parent and Anticheat.ChecksEnabled.AccoutrementDeletion or child.Parent == workspace and Anticheat.ChecksEnabled.PreventAccoutrementDrop) then
 									child.Parent = character
 								end
 							end)
@@ -275,12 +275,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and (Anticheat.ChecksEnabled.PreventAccoutrementDrop or Anticheat.ChecksEnabled.AccroutrementDeletion) then
+						elseif child:IsA("Accoutrement") and (Anticheat.ChecksEnabled.PreventAccoutrementDrop or Anticheat.ChecksEnabled.AccoutrementDeletion) then
 							ConnectAccoutrementDrop(child)
 						end
 					end)
 
-					if Anticheat.ChecksEnabled.PreventAccoutrementDrop or Anticheat.ChecksEnabled.AccroutrementDeletion then
+					if Anticheat.ChecksEnabled.PreventAccoutrementDrop or Anticheat.ChecksEnabled.AccoutrementDeletion then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
 								ConnectAccoutrementDrop(child)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -200,7 +200,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 							local connection
 							connection = child.AncestryChanged:Connect(function(_, parent)
 								-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
-								if child.Parent == character or Players:GetPlayerFromCharacter(child.Parent) or child.Parent:FindFirstChildOfClass("Humanoid") then -- Makes stuff like admin commands which exchange hats work.
+								if child.Parent == character or Players:GetPlayerFromCharacter(child.Parent) then -- Makes stuff like admin commands which exchange hats work.
 									return
 								end
 

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,7 +61,7 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	CanDropAccroutrements = false, -- If players can drop hats(and other accessories) via a hat drop script. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
+	CanParentAccroutrements = false, -- If players can drop and/or delete hats(and other accessories). If you have hat drop scripts turn this to true. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
 	DestroyDroppedHats = true, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
@@ -282,12 +282,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanDropAccroutrements then
+						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanParentAccroutrements then
 							ConnectHatDrop(child)
 						end
 					end)
 
-					if not Anticheat.ChecksEnabled.CanDropAccroutrements then
+					if not Anticheat.ChecksEnabled.CanParentAccroutrements then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
 								ConnectHatDrop(child)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -193,6 +193,23 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 					end
 
 					local stillConnected = setmetatable({}, {__mode="kv"})
+					local function ConnectHatDrop(child)
+						if not stillConnected[child] then
+							local connection
+							connection = child.AncestryChanged:Connect(function(_, parent)
+								-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
+								if parent == character then
+									return
+								end
+
+								-- Invalid hat drop or hat got destroyed
+								stillConnected[child] = nil
+								child:Destroy()
+								connection:Disconnect()
+								connection = nil
+							end)
+						end
+					end
 					character.ChildAdded:Connect(function(child)
 						if child:IsA("Humanoid") then
 							trackHumanoid()
@@ -253,42 +270,14 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								end
 							end
 						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanHatsBeDropped then
-							if not stillConnected[child] then
-								local connection
-								connection = child.AncestryChanged:Connect(function(_, parent)
-									-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
-									if parent == character then
-										return
-									end
-
-									-- Invalid hat drop or hat got destroyed
-									stillConnected[child] = nil
-									child:Destroy()
-									connection:Disconnect()
-									connection = nil
-								end)
-							end
+							ConnectHatDrop(child)
 						end
 					end)
 
 					if not Anticheat.ChecksEnabled.CanHatsBeDropped then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
-								if not stillConnected[child] then
-									local connection
-									connection = child.AncestryChanged:Connect(function(_, parent)
-										-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
-										if parent == character then
-											return
-										end
-
-										-- Invalid hat drop or hat got destroyed
-										stillConnected[child] = nil
-										child:Destroy()
-										connection:Disconnect()
-										connection = nil
-									end)
-								end
+								ConnectHatDrop(child)
 							end
 						end
 					end

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,7 +61,8 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	CanHatsBeDropped = false, -- If players can drop hats via a hat drop script. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
+	CanDropAccroutements = false, -- If players can drop hats(and other accessories) via a hat drop script. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
+	DestroyDroppedHats = true, -- If invalidly dropped and/or deleted accroutements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player
@@ -201,12 +202,21 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								-- Yeah, AncestryChanged fires after ChildAdded... Makes sense to me!
 								if parent == character or Players:GetPlayerFromCharacter(parent) then
 									return
+								elseif not character or not character:IsDescendantOf(game) then
+									stillConnected[child] = nil
+									connection:Disconnect()
+									connection = nil
+									child:Destroy() -- Character is missing or respawned. Accroutrements should exist after this so we must clear it.
 								end
 
 								humanoid:WaitForChild("\0", 1e-6) -- Hacky way to yield for a very very tiny amount of time
 								-- Invalid hat drop or hat got destroyed
 								stillConnected[child] = nil
-								child:Destroy()
+								if Anticheat.ChecksEnabled.DestroyDroppedHats then
+									child:Destroy()
+								else
+									child.Parent = character
+								end
 								connection:Disconnect()
 								connection = nil
 							end)
@@ -272,12 +282,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanHatsBeDropped then
+						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanDropAccroutements then
 							ConnectHatDrop(child)
 						end
 					end)
 
-					if not Anticheat.ChecksEnabled.CanHatsBeDropped then
+					if not Anticheat.ChecksEnabled.CanDropAccroutements then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
 								ConnectHatDrop(child)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -208,6 +208,7 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 								connection:Disconnect()
 								connection = nil
 							end)
+							stillConnected[child] = connection
 						end
 					end
 					character.ChildAdded:Connect(function(child)

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,8 +61,8 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	PreventAccoutrementDrop = true, -- If players can drop and hats(and other accessories). If you have a custom hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed.
-	AccroutrementDeletion = true, -- If it prevents the deletion of accroutrements. Note you will have to have PreventParentAccoutrements on.
+	PreventAccoutrementDrop = true, -- If players can drop and hats(and other accessories). Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop scripts turn this to false.
+	AccroutrementDeletion = true, -- If it prevents the deletion of accoutrements.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -62,7 +62,7 @@ Anticheat.ChecksEnabled = {
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
 	PreventParentAccoutrements = true, -- If players can drop and/or delete hats(and other accessories). If you have a custom hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed.
-	DestroyDroppedAccoutrements = true, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
+	DestroyDroppedAccoutrements = false, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
 	--ServerOwnedLimbs = true, -- Make sure limbs are server owned when detached from the player

--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -61,7 +61,7 @@ Anticheat.ChecksEnabled = {
 	InvalidDrop = true, -- Dropping tools that don't have CanBeDropped
 	ToolDeletion = true, -- Stop the client from deleting tools (Incompatible with any usage of tool.Parent = nil, use :Destroy() instead)
 	FEGodMode = true, -- God mod achieved by deleting their Humanoid on the server and creating a fake one on the client
-	CanParentAccroutrements = false, -- If players can drop and/or delete hats(and other accessories). If you have hat drop scripts turn this to true. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to true.
+	PreventParentAccroutrements = true, -- If players can drop and/or delete hats(and other accessories). If you have hat drop scripts turn this to false. Up to 2017 you could drop hats via the = key however this was removed. If you have a custom hat drop script set this to false.
 	DestroyDroppedHats = true, -- If invalidly dropped and/or deleted accroutrements(hats and accessories) get deleted or parented back to the character.
 
 	-- Upcoming checks
@@ -277,12 +277,12 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 									end
 								end
 							end
-						elseif child:IsA("Accoutrement") and not Anticheat.ChecksEnabled.CanParentAccroutrements then
+						elseif child:IsA("Accoutrement") and Anticheat.ChecksEnabled.PreventParentAccroutrements then
 							ConnectHatDrop(child)
 						end
 					end)
 
-					if not Anticheat.ChecksEnabled.CanParentAccroutrements then
+					if Anticheat.ChecksEnabled.PreventParentAccroutrements then
 						for _, child in ipairs(character:GetChildren()) do
 							if child:IsA("Accoutrement") then
 								ConnectHatDrop(child)


### PR DESCRIPTION
This stops exploiters from dropping hats. Some games have hat drop scripts so I added a setting called CanHatsBeDropped. It is defaulted to false as most games do not have a hat drop script but if they do they can set it to true.
If you find any bugs or known a way to do this shorter plz tell me. ;)