### PR TITLE
Fixed multitool.

### DIFF
--- a/Anticheat/src/init.lua
+++ b/Anticheat/src/init.lua
@@ -246,7 +246,6 @@ function Anticheat:TestPlayers(PlayerManager, delta)
 											-- If we already have a tool, we want to move this one back to the player's backpack
 											-- This also avoids conflicts where a tool is given to the player by the server
 											child.Parent = player:FindFirstChildWhichIsA("Backpack") or Instance.new("Backpack", player)
-											break
 										end
 									end
 								end


### PR DESCRIPTION
Fixed a bug. Before it only deselected one tool meaning if you selected more than 2 tools at the same time you could still multitool. But it should ideally sue https://developer.roblox.com/en-us/api-reference/function/Humanoid/UnequipTools